### PR TITLE
CI: Allow passing pre-release Python versions to setup-python

### DIFF
--- a/.github/workflows/test-dependents.yml
+++ b/.github/workflows/test-dependents.yml
@@ -67,6 +67,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
+          allow-prereleases: true
 
       - name: Setup Headless Display
         if: ${{ inputs.qt != '' }}

--- a/.github/workflows/test-pyrepo.yml
+++ b/.github/workflows/test-pyrepo.yml
@@ -145,6 +145,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           cache-dependency-path: ${{ inputs.python-cache-dependency-path }}
           cache: pip
+          allow-prereleases: true
 
       - run: python -m pip install --upgrade pip
 

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+          allow-prereleases: true
 
       - name: Install coverage
         run: pip install coverage


### PR DESCRIPTION
This allows Python 3.13, which is now in release candidate phase, to also be setup.

Ref https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases